### PR TITLE
Add a firmware build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Firmware Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      PICO_SDK_URL: https://github.com/raspberrypi/pico-sdk.git
+      PICO_SDK_VERSION: 1.3.1
+      ARM_URL_COMMON: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10
+      ARM_FILENAME_LINUX: gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+      ARM_DIR: arm-toolchain
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Clone Raspberry Pi Pico SDK and submodules
+        run: |
+          mkdir deps
+          cd deps
+          git clone ${PICO_SDK_URL} -b ${PICO_SDK_VERSION} --depth 1
+          cd pico-sdk
+          git submodule init
+          git submodule update --depth 1
+
+      - name: Download and install the ARM toolchain
+        run: |
+          cd deps
+          wget --progress=dot:giga ${ARM_URL_COMMON}/${ARM_FILENAME_LINUX}
+          mkdir ${ARM_DIR}
+          tar jxf ${ARM_FILENAME_LINUX} --directory ${ARM_DIR} --strip-components 1
+          rm ${ARM_FILENAME_LINUX}
+
+      - name: Configure CMake
+        run: cmake -B build
+
+      - name: Build
+        run: |
+          cmake --build build
+          ls -l build
+
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: alpakka
+          path: build/alpakka.uf2


### PR DESCRIPTION
Hey folks, I took the install and build script and rewrote it in the form of a GitHub workflow with few minor tweaks. 

This runs a build of the firmware for every push you do on the main branch, but also for every pull request. Once it finishes successfully, you can go to the workflow page summary and download the produced firmware with the relevant changes.

I can think of few good reasons why this may be useful for the project:
- For pull requests, just to make sure that they build, that'd be vital once you'll start getting more external PRs.
- For the main build, it ensures that the firmware has been build in an hermetic environment: that is, it does not depend on something you had on your local workstation and other users can reproduce it. This could be extended to react to tags and automatically create a GitHub release as well.
- For the user, right now since there's no dynamic configuration system (and I'd argue that it should stay that way) if one wants to customize the profiles, they have to set-up the development environment and do a custom build. What they could do instead is fork the repository, edit the profile files, push the change, wait a minute to get the new custom firmware from GitHub and flash it on the controller.

The last point is the most interesting, this is how ZMK works (https://zmk.dev/docs/customization#publishing) and I think may be a better solution than having to deal with MSD, text files etc. Instead of messing with that maybe you could do an online configuration tool that spits out a file to upload on github and get back a custom firmware.

As for the action pricing, IIUC it should be free for public repos (https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-billing-for-github-actions).

Let me know what you think. 