### PR TITLE
Fix reporting zero position when the reading is exactly 0

### DIFF
--- a/src/thumbstick.c
+++ b/src/thumbstick.c
@@ -110,10 +110,10 @@ void Thumbstick__report_4dir(
     // Report push.
     self->push.report(&self->push);
     // Report axis.
-    if (pos.x < 0) thumbstick_report_axis(self->left.actions[0],  -pos.x);
-    if (pos.x > 0) thumbstick_report_axis(self->right.actions[0],  pos.x);
-    if (pos.y < 0) thumbstick_report_axis(self->up.actions[0],    -pos.y);
-    if (pos.y > 0) thumbstick_report_axis(self->down.actions[0],   pos.y);
+    if (pos.x < 0) thumbstick_report_axis(self->left.actions[0],   -pos.x);
+    if (pos.x >= 0) thumbstick_report_axis(self->right.actions[0],  pos.x);
+    if (pos.y < 0) thumbstick_report_axis(self->up.actions[0],     -pos.y);
+    if (pos.y >= 0) thumbstick_report_axis(self->down.actions[0],   pos.y);
 }
 
 void Thumbstick__report(Thumbstick *self) {


### PR DESCRIPTION
Current thumbstick reporting does not report at all when the analog reading after the sin() or cos() is exactly 0 (that is 0.0f), so right now it only emits a zero when the reading is not exactly zero but low enough to go to zero once multiplied by ANALOG_FACTOR and casted to integer.

The issue can be reproduced by pulling the analog stick to a corner and letting it go to center quickly, the last report is often not 0 and only centers again after nudging the stick.

Changing the trigger condition to also include a zero value seems to fix the problem.