### PR TITLE
Refactor hid_procedure_press to switch and optimize 

### DIFF
--- a/src/button.c
+++ b/src/button.c
@@ -38,15 +38,12 @@ bool Button__is_pressed(Button *self) {
 }
 
 void Button__report(Button *self) {
-    if (self->behavior == NORMAL) self->handle_normal(self);
-    else if (self->behavior == STICKY) self->handle_sticky(self);
-    else if (self->behavior == HOLD_OVERLAP) self->handle_hold_overlap(self);
-    else if (self->behavior == HOLD_DOUBLE_PRESS) self->handle_hold_double_press(self);
-    else if (self->behavior == HOLD_EXCLUSIVE) {
-        self->handle_hold_exclusive(self, CFG_HOLD_EXCLUSIVE_TIME);
-    }
-    else if (self->behavior == HOLD_EXCLUSIVE_LONG) {
-        self->handle_hold_exclusive(self, CFG_HOLD_EXCLUSIVE_LONG_TIME);
+    switch (self->behavior) {
+        case NORMAL: self->handle_normal(self); break;
+        case STICKY: self->handle_sticky(self); break;
+        case HOLD_DOUBLE_PRESS: self->handle_hold_overlap(self); break;
+        case HOLD_EXCLUSIVE: self->handle_hold_exclusive(self, CFG_HOLD_EXCLUSIVE_TIME); break;
+        case HOLD_EXCLUSIVE_LONG: self->handle_hold_exclusive(self, CFG_HOLD_EXCLUSIVE_LONG_TIME); break;
     }
 }
 

--- a/src/hid.c
+++ b/src/hid.c
@@ -36,35 +36,39 @@ void hid_matrix_reset() {
 }
 
 void hid_procedure_press(uint8_t procedure){
-    if (procedure == PROC_HOME) profile_set_home(true);                  // Hold home.
-    if (procedure == PROC_HOME_GAMEPAD) profile_set_home_gamepad(true);  // Double-click-hold home.
-    if (procedure == PROC_PROFILE_1) profile_set_active(1);
-    if (procedure == PROC_PROFILE_2) profile_set_active(2);
-    if (procedure == PROC_PROFILE_3) profile_set_active(3);
-    if (procedure == PROC_PROFILE_4) profile_set_active(4);
-    if (procedure == PROC_PROFILE_5) profile_set_active(5);
-    if (procedure == PROC_PROFILE_6) profile_set_active(6);
-    if (procedure == PROC_PROFILE_7) profile_set_active(7);
-    if (procedure == PROC_PROFILE_8) profile_set_active(8);
-    if (procedure == PROC_PROFILE_9) profile_set_active(9);
-    if (procedure == PROC_PROFILE_10) profile_set_active(10);
-    if (procedure == PROC_PROFILE_11) profile_set_active(11);
-    if (procedure == PROC_PROFILE_12) profile_set_active(12);
-    if (procedure == PROC_TUNE_UP) config_tune(1);
-    if (procedure == PROC_TUNE_DOWN) config_tune(0);
-    if (procedure == PROC_TUNE_OS) config_tune_set_mode(procedure);
-    if (procedure == PROC_TUNE_SENSITIVITY) config_tune_set_mode(procedure);
-    if (procedure == PROC_TUNE_DEADZONE) config_tune_set_mode(procedure);
-    if (procedure == PROC_TUNE_TOUCH_THRESHOLD) config_tune_set_mode(procedure);
-    if (procedure == PROC_TUNE_VIBRATION) config_tune_set_mode(procedure);
-    if (procedure == PROC_CALIBRATE) config_calibrate();
-    if (procedure == PROC_BOOTSEL) config_bootsel();
-    if (procedure == PROC_THANKS) hid_thanks();
+    switch (procedure){
+        case PROC_HOME: profile_set_home(true); break;                  // Hold home. 
+        case PROC_HOME_GAMEPAD: profile_set_home_gamepad(true); break;  // Double-click-hold home.
+        case PROC_PROFILE_1: profile_set_active(1); break;
+        case PROC_PROFILE_2: profile_set_active(2); break;
+        case PROC_PROFILE_3: profile_set_active(3); break;
+        case PROC_PROFILE_4: profile_set_active(4); break;
+        case PROC_PROFILE_5: profile_set_active(5); break;
+        case PROC_PROFILE_6: profile_set_active(6); break;
+        case PROC_PROFILE_7: profile_set_active(7); break;
+        case PROC_PROFILE_8: profile_set_active(8); break;
+        case PROC_PROFILE_9: profile_set_active(9); break;
+        case PROC_PROFILE_10: profile_set_active(10); break;
+        case PROC_PROFILE_11: profile_set_active(11); break;
+        case PROC_PROFILE_12: profile_set_active(12); break;
+        case PROC_TUNE_UP: config_tune(1); break;
+        case PROC_TUNE_DOWN: config_tune(0); break;
+        case PROC_TUNE_OS: config_tune_set_mode(procedure); break;
+        case PROC_TUNE_SENSITIVITY: config_tune_set_mode(procedure); break;
+        case PROC_TUNE_DEADZONE: config_tune_set_mode(procedure); break;
+        case PROC_TUNE_TOUCH_THRESHOLD: config_tune_set_mode(procedure); break;
+        case PROC_TUNE_VIBRATION: config_tune_set_mode(procedure); break;
+        case PROC_CALIBRATE: config_calibrate(); break;
+        case PROC_BOOTSEL: config_bootsel(); break;
+        case PROC_THANKS: hid_thanks(); break;
+    }
 }
 
 void hid_procedure_release(uint8_t procedure) {
-    if (procedure == PROC_HOME) profile_set_home(false);
-    if (procedure == PROC_HOME_GAMEPAD) profile_set_home_gamepad(false);
+    switch (procedure) {
+        case PROC_HOME: profile_set_home(false); break;
+        case PROC_HOME_GAMEPAD: profile_set_home_gamepad(false); break; 
+    }
 }
 
 void hid_press(uint8_t key) {

--- a/src/thumbstick.c
+++ b/src/thumbstick.c
@@ -83,16 +83,18 @@ void thumbstick_init() {
 }
 
 void thumbstick_report_axis(uint8_t axis, float value) {
-    if      (axis == GAMEPAD_AXIS_LX)     hid_gamepad_lx( value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_LY)     hid_gamepad_ly(-value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_RX)     hid_gamepad_rx( value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_RY)     hid_gamepad_ry(-value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_LX_NEG) hid_gamepad_lx(-value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_LY_NEG) hid_gamepad_ly( value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_RX_NEG) hid_gamepad_rx(-value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_RY_NEG) hid_gamepad_ry( value * ANALOG_FACTOR);
-    else if (axis == GAMEPAD_AXIS_LZ) hid_gamepad_lz(max(0, value) * TRIGGER_FACTOR);
-    else if (axis == GAMEPAD_AXIS_RZ) hid_gamepad_rz(max(0, value) * TRIGGER_FACTOR);
+    switch (axis) {
+        case GAMEPAD_AXIS_LX: hid_gamepad_lx( value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_LY: hid_gamepad_ly(-value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_RX: hid_gamepad_rx( value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_RY: hid_gamepad_ry(-value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_LX_NEG: hid_gamepad_lx(-value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_LY_NEG: hid_gamepad_ly( value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_RX_NEG: hid_gamepad_rx(-value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_RY_NEG: hid_gamepad_ry( value * ANALOG_FACTOR); break;
+        case GAMEPAD_AXIS_LZ: hid_gamepad_lz(max(0, value) * TRIGGER_FACTOR); break;
+        case GAMEPAD_AXIS_RZ: hid_gamepad_rz(max(0, value) * TRIGGER_FACTOR); break;
+    }
 }
 
 void Thumbstick__report_4dir(


### PR DESCRIPTION
The `procedure` can only equal to one of the  `#defines`. Refacted `hid_procedure_press` to use a switch. Also refactored other places to use `switch case` as it should be evaluated faster unless the compiler optimizes the `if else`.