### PR TITLE
Print IMU id during initialization.

### DIFF
--- a/src/headers/imu.h
+++ b/src/headers/imu.h
@@ -9,6 +9,7 @@
 #define IMU_OUTX_L_G 0x22
 #define IMU_OUTY_L_G 0x24
 #define IMU_OUTZ_L_G 0x26
+#define IMU_WHO_AM_I 0x0f
 
 #define IMU_CTRL2_G_125 0b10100010
 #define IMU_CTRL2_G_500 0b10100100

--- a/src/imu.c
+++ b/src/imu.c
@@ -27,9 +27,10 @@ double offset_1_y;
 double offset_1_z;
 
 void imu_init_single(uint8_t cs, uint8_t gyro_conf) {
+    uint8_t id = bus_spi_read_one(cs, IMU_WHO_AM_I);
     bus_spi_write(cs, IMU_CTRL2_G, gyro_conf);
     uint8_t ctrl = bus_spi_read_one(cs, IMU_CTRL2_G);
-    printf("  IMU cs=%i ctrl2_g=0x%i\n", cs, bin(ctrl));
+    printf("  IMU cs=%i id=0x%02x ctrl2_g=0x%i\n", cs, id, bin(ctrl));
 }
 
 void imu_init() {


### PR DESCRIPTION
This can be useful to validate that the IMUs are soldered correctly.