### PR TITLE
Add an option to swap the A/B and X/Y buttons 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ deps/
 .vscode
 **/.DS_Store
 src/headers/version.h
+.cache/
+compile_commands.json

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -17,6 +17,9 @@
 #define CFG_LOG_LEVEL 0
 #define CFG_LED_BRIGHTNESS 0.2
 
+// Swap A/B and X/Y buttons for all console modes, like on a Nintendo Switch Controller.
+#define CFG_SWAP_AB_XY false
+
 #define CFG_TICK_FREQUENCY 250  // Hz.
 #define CFG_HID_REPORT_PRIORITY_RATIO 8
 

--- a/src/profiles/console.c
+++ b/src/profiles/console.c
@@ -2,6 +2,7 @@
 // Copyright (C) 2022, Input Labs Oy.
 
 #include <stdio.h>
+#include "config.h"
 #include "pin.h"
 #include "hid.h"
 #include "button.h"
@@ -19,11 +20,17 @@ Profile profile_init_console() {
     profile.dpad_right = Button_(PIN_DPAD_RIGHT, NORMAL, ACTIONS(GAMEPAD_RIGHT));
     profile.dpad_up =    Button_(PIN_DPAD_UP,    NORMAL, ACTIONS(GAMEPAD_UP));
     profile.dpad_down =  Button_(PIN_DPAD_DOWN,  NORMAL, ACTIONS(GAMEPAD_DOWN));
-
-    profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
-    profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
-    profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
-    profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    if (!CFG_SWAP_AB_XY) {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    } else {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_Y));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_X));
+    }
 
     profile.l1 = Button_(PIN_L1, NORMAL, ACTIONS(GAMEPAD_L1));
     profile.r1 = Button_(PIN_R1, NORMAL, ACTIONS(GAMEPAD_R1));

--- a/src/profiles/console_legacy.c
+++ b/src/profiles/console_legacy.c
@@ -2,6 +2,7 @@
 // Copyright (C) 2022, Input Labs Oy.
 
 #include <stdio.h>
+#include "config.h"
 #include "pin.h"
 #include "hid.h"
 #include "button.h"
@@ -20,10 +21,17 @@ Profile profile_init_console_legacy() {
     profile.dpad_up =    Button_(PIN_DPAD_UP,    NORMAL, ACTIONS(GAMEPAD_UP));
     profile.dpad_down =  Button_(PIN_DPAD_DOWN,  NORMAL, ACTIONS(GAMEPAD_DOWN));
 
-    profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
-    profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
-    profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
-    profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    if (!CFG_SWAP_AB_XY) {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    } else {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_Y));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_X));
+    }
 
     profile.l1 = Button_(PIN_L1, NORMAL, ACTIONS(GAMEPAD_L1));
     profile.r1 = Button_(PIN_R1, NORMAL, ACTIONS(GAMEPAD_R1));

--- a/src/profiles/racing.c
+++ b/src/profiles/racing.c
@@ -2,6 +2,7 @@
 // Copyright (C) 2022, Input Labs Oy.
 
 #include <stdio.h>
+#include "config.h"
 #include "pin.h"
 #include "hid.h"
 #include "button.h"
@@ -20,10 +21,17 @@ Profile profile_init_racing() {
     profile.dpad_up =    Button_(PIN_DPAD_UP,    NORMAL, ACTIONS(GAMEPAD_UP));
     profile.dpad_down =  Button_(PIN_DPAD_DOWN,  NORMAL, ACTIONS(GAMEPAD_DOWN));
 
-    profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
-    profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
-    profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
-    profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    if (!CFG_SWAP_AB_XY) {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_X));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_Y));
+    } else {
+        profile.a = Button_(PIN_A, NORMAL, ACTIONS(GAMEPAD_B));
+        profile.b = Button_(PIN_B, NORMAL, ACTIONS(GAMEPAD_A));
+        profile.x = Button_(PIN_X, NORMAL, ACTIONS(GAMEPAD_Y));
+        profile.y = Button_(PIN_Y, NORMAL, ACTIONS(GAMEPAD_X));
+    }
 
     profile.l1 = Button_(PIN_L1, NORMAL, ACTIONS(GAMEPAD_L1));
     profile.r1 = Button_(PIN_R1, NORMAL, ACTIONS(GAMEPAD_R1));


### PR DESCRIPTION
Add the configuration option to swap the A/B and X/Y button action in all profiles that send console keys, make the button name same as the Nintendo Switch's controllers'.
Probably this should also be able to change in runtime?