### PR TITLE
fix load script

### DIFF
--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022, Input Labs Oy.
 
 UF2=build/alpakka.uf2
-DRIVE_LINUX="/media/RPI-RP2"
+DRIVE_LINUX="/media/${USER}/RPI-RP2"
 DRIVE_MACOS="/Volumes/RPI-RP2"
 DRIVE_WSL="/mnt/RPI-RP2"
 WSL=0


### PR DESCRIPTION
Add user name to Linux mnt location

Not sure if it is the general case but at least on my Linux machine:

Ubuntu 20.04 LTS it is mounted to

/media/${USER}/RPI-RP2

not to 

/media/RPI-RP2