### PR TITLE
Disable home-sleep if home profile is used

### DIFF
--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -59,7 +59,7 @@
 #define CFG_HOLD_TIME 200  // Milliseconds.
 #define CFG_HOLD_LONG_TIME 2000  // Milliseconds.
 #define CFG_DOUBLE_PRESS_TIME 300  // Milliseconds.
-#define CFG_HOME_SLEEP_TIME 4000  // Milliseconds.
+#define CFG_HOME_SLEEP_TIME 5000  // Milliseconds.
 
 #define CFG_DHAT_DEBOUNCE_TIME 100  // Milliseconds.
 

--- a/src/headers/profile.h
+++ b/src/headers/profile.h
@@ -73,6 +73,7 @@ void profile_set_home(bool state);
 void profile_set_home_gamepad(bool state);
 void profile_set_active(uint8_t index);
 void profile_set_lock_leds(bool lock);
+void profile_set_reported_inputs(bool value);
 void profile_update_leds();
 void profile_enable_all(bool value);
 void profile_enable_abxy(bool value);

--- a/src/hid.c
+++ b/src/hid.c
@@ -149,9 +149,12 @@ void hid_release(uint8_t key) {
 
 void hid_press_multiple(uint8_t *keys) {
     for(uint8_t i=0; i<ACTIONS_LEN; i++) {
-        if (keys[i] == 0) return;
+        if (keys[i] == 0) break;
         hid_press(keys[i]);
     }
+    if (keys[0] == PROC_HOME) return; // Home does not count as input.
+    profile_set_reported_inputs(true);
+
 }
 
 void hid_release_multiple(uint8_t *keys) {
@@ -253,10 +256,12 @@ void hid_mouse_move(int16_t x, int16_t y) {
     mouse_x += x;
     mouse_y += y;
     synced_mouse = false;
+    profile_set_reported_inputs(true);
 }
 
 void hid_gamepad_axis(GamepadAxis axis, double value) {
     gamepad_axis[axis] += value;  // Multiple inputs can be combined.
+    if (value != 0) profile_set_reported_inputs(true);
 }
 
 MouseReport hid_get_mouse_report() {


### PR DESCRIPTION
Final tweaks for the hold-home-to-sleep feature.

If any input is sent (from the home profile) the feature is disabled.

Additionally `profile_reported_inputs` could be used in the future for the auto-power-off feature, if there are no sent inputs for some time.
