### PR TITLE
fix: suppress git describe error output when no tags exist

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,6 +1,6 @@
 HEADER_PATH="src/headers/version.h"
 
-if ( git describe --tags ); then
+if ( git describe --tags 2>/dev/null ); then
     TAG=`git describe --tags`
 else
     TAG=${GITHUB_REF}


### PR DESCRIPTION
- Redirect stderr to /dev/null in version.sh to prevent 'fatal: No names found' error
- This eliminates the warning message during build process when repository has no git tags
- Build process now runs cleanly without error output from version script