### PR TITLE
zig: incremental Zig integration via static lib & unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ deps*/
 .vscode
 **/.DS_Store
 src/headers/version.h
+zig/.zig-cache/
+zig/zig-out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,16 @@ add_executable(${PROJECT}
     src/main.c
 )
 
+# Build Zig static library and link it
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/zig/zig-out/lib/libalpakka_zig.a
+    COMMAND zig build -Dtarget=arm-freestanding-eabi -Dcpu=cortex_m0plus -Drelease-small=true
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/zig
+    COMMENT "Building Zig static library"
+)
+add_custom_target(ziglib ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/zig/zig-out/lib/libalpakka_zig.a)
+add_dependencies(${PROJECT} ziglib)
+
 if(DEFINED DEVICE)
     if(DEVICE MATCHES "alpakka_v0")
         target_compile_definitions(${PROJECT} PUBLIC DEVICE_ALPAKKA_V0=1)
@@ -51,6 +61,11 @@ endif()
 
 # Enable all warnings and promote them to errors.
 target_compile_options(${PROJECT} PRIVATE -Wall -Werror)
+
+# Link the Zig static library path
+target_link_libraries(${PROJECT} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/zig/zig-out/lib/libalpakka_zig.a
+)
 
 target_link_libraries(${PROJECT} PRIVATE
     pico_stdlib

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ install:
 clean:
 	rm -rf build
 	rm -f src/headers/version.h
+	rm -rf zig/zig-out
+	rm -rf zig/.zig-cache
 
 load:
 	sh -e scripts/load.sh

--- a/src/headers/zig_abi.h
+++ b/src/headers/zig_abi.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "vector.h"
+
+Vector zig_vector_normalize(Vector v); 

--- a/src/vector.c
+++ b/src/vector.c
@@ -3,14 +3,10 @@
 
 #include <math.h>
 #include "vector.h"
+#include "zig_abi.h"
 
 Vector vector_normalize(Vector v) {
-    float mag = (v.x*v.x) + (v.y*v.y) + (v.z*v.z);
-    if (fabs(mag - 1.0) > 0.0001) {  // Tolerance.
-        mag = sqrt(mag);
-        return (Vector){v.x/mag, v.y/mag, v.z/mag};
-    }
-    return v;
+    return zig_vector_normalize(v);
 }
 
 Vector vector_add(Vector a, Vector b) {

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const release_small = b.option(bool, "release-small", "Build with ReleaseSmall optimization") orelse false;
+    const optimize: std.builtin.OptimizeMode = if (release_small) .ReleaseSmall else .Debug;
+
+    const lib = b.addStaticLibrary(.{
+        .name = "alpakka_zig",
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    b.installArtifact(lib);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_tests = b.addRunArtifact(unit_tests);
+    const test_step = b.step("test", "Run Zig unit tests");
+    test_step.dependOn(&run_tests.step);
+} 

--- a/zig/src/lib.zig
+++ b/zig/src/lib.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+pub const Vector = extern struct {
+    x: f64,
+    y: f64,
+    z: f64,
+};
+
+pub export fn zig_vector_normalize(v: Vector) callconv(.C) Vector {
+    const mag2: f64 = v.x * v.x + v.y * v.y + v.z * v.z;
+    const diff: f64 = @abs(mag2 - 1.0);
+    if (diff > 0.0001) {
+        const mag: f64 = @sqrt(mag2);
+        return .{ .x = v.x / mag, .y = v.y / mag, .z = v.z / mag };
+    }
+    return v;
+}
+
+test "zig_vector_normalize makes unit length (3,4,0) -> (0.6,0.8,0)" {
+    const v = Vector{ .x = 3.0, .y = 4.0, .z = 0.0 };
+    const n = zig_vector_normalize(v);
+    try std.testing.expect(std.math.approxEqAbs(f64, n.x, 0.6, 1e-10));
+    try std.testing.expect(std.math.approxEqAbs(f64, n.y, 0.8, 1e-10));
+    try std.testing.expect(std.math.approxEqAbs(f64, n.z, 0.0, 1e-10));
+    const len = @sqrt(n.x * n.x + n.y * n.y + n.z * n.z);
+    try std.testing.expect(std.math.approxEqAbs(f64, len, 1.0, 1e-12));
+}
+
+test "zig_vector_normalize returns same vector if already unit" {
+    const v = Vector{ .x = 1.0, .y = 0.0, .z = 0.0 };
+    const n = zig_vector_normalize(v);
+    try std.testing.expect(std.math.approxEqAbs(f64, n.x, 1.0, 0.0));
+    try std.testing.expect(std.math.approxEqAbs(f64, n.y, 0.0, 0.0));
+    try std.testing.expect(std.math.approxEqAbs(f64, n.z, 0.0, 0.0));
+} 


### PR DESCRIPTION
- Scaffold Zig project under zig/ with build.zig producing static lib (libalpakka_zig.a).
- Implement C-ABI function zig_vector_normalize and two tiny Zig tests.
- Add header src/headers/zig_abi.h; delegate vector_normalize() in src/vector.c to Zig.
- Extend CMake to build/link Zig lib (custom target ziglib) into RP2040 firmware.
- Update Makefile clean to remove Zig artifacts (zig/zig-out, zig/.zig-cache).
- Update .gitignore for Zig build outputs.

Build:
- Firmware: DEVICE=alpakka_v1 make succeeds.
- Tests: zig test zig/src/lib.zig pass.